### PR TITLE
Fix for Invalid byte 1 of 1-byte UTF-8 sequence

### DIFF
--- a/src/main/java/nz/co/breakpoint/jmeter/modifiers/AbstractWSSecurityPreProcessor.java
+++ b/src/main/java/nz/co/breakpoint/jmeter/modifiers/AbstractWSSecurityPreProcessor.java
@@ -113,7 +113,7 @@ public abstract class AbstractWSSecurityPreProcessor extends AbstractTestElement
 
 		try {
 			log.debug("Parsing xml payload");
-			Document doc = docBuilder.parse(new ByteArrayInputStream(xml.getBytes()));
+			Document doc = docBuilder.parse(new ByteArrayInputStream(xml.getBytes("UTF-8")));
 
 			log.debug("Initializing WSS header");
 			WSSecHeader secHeader = new WSSecHeader(doc);


### PR DESCRIPTION
Possible fix for the Invalid byte 1 of 1-byte UTF-8 sequence thrown on JMeter script execution.