### PR TITLE
Add timestamp precision

### DIFF
--- a/src/main/java/nz/co/breakpoint/jmeter/modifiers/WSSUsernameTokenPreProcessor.java
+++ b/src/main/java/nz/co/breakpoint/jmeter/modifiers/WSSUsernameTokenPreProcessor.java
@@ -23,6 +23,7 @@ public class WSSUsernameTokenPreProcessor extends AbstractWSSecurityPreProcessor
     private String passwordType;
     private boolean addNonce;
     private boolean addCreated;
+    private boolean precisionInMilliSeconds;
 
     static final Map<String, String> passwordTypeMap = new HashMap<String, String>();
     static {
@@ -66,6 +67,7 @@ public class WSSUsernameTokenPreProcessor extends AbstractWSSecurityPreProcessor
     protected Document build(Document document, WSSecHeader secHeader) throws WSSecurityException {
         if (addNonce) secBuilder.addNonce();
         if (addCreated) secBuilder.addCreated();
+        secBuilder.setPrecisionInMilliSeconds(precisionInMilliSeconds);
         return secBuilder.build(document, secHeader);
     }
 
@@ -94,7 +96,15 @@ public class WSSUsernameTokenPreProcessor extends AbstractWSSecurityPreProcessor
         this.addCreated = addCreated;
     }
 
-    // Make accessors public for bean introspector to build the GUI.
+    public boolean isPrecisionInMilliSeconds() {
+		return precisionInMilliSeconds;
+	}
+
+	public void setPrecisionInMilliSeconds(boolean precisionInMilliSeconds) {
+		this.precisionInMilliSeconds = precisionInMilliSeconds;
+	}
+
+	// Make accessors public for bean introspector to build the GUI.
     public String getUsername() {
         return super.getUsername();
     }

--- a/src/main/java/nz/co/breakpoint/jmeter/modifiers/WSSUsernameTokenPreProcessorBeanInfo.java
+++ b/src/main/java/nz/co/breakpoint/jmeter/modifiers/WSSUsernameTokenPreProcessorBeanInfo.java
@@ -9,7 +9,7 @@ public class WSSUsernameTokenPreProcessorBeanInfo extends AbstractWSSecurityPreP
         super(WSSUsernameTokenPreProcessor.class);
 
         createPropertyGroup("UsernameToken", new String[]{ 
-            "username", "password", "passwordType", "addNonce", "addCreated"
+            "username", "password", "passwordType", "addNonce", "addCreated", "precisionInMilliSeconds"
         });
         PropertyDescriptor p;
 
@@ -33,6 +33,10 @@ public class WSSUsernameTokenPreProcessorBeanInfo extends AbstractWSSecurityPreP
         p.setValue(DEFAULT, Boolean.TRUE);
 
         p = property("addCreated");
+        p.setValue(NOT_UNDEFINED, Boolean.TRUE);
+        p.setValue(DEFAULT, Boolean.TRUE);
+        
+        p = property("precisionInMilliSeconds");
         p.setValue(NOT_UNDEFINED, Boolean.TRUE);
         p.setValue(DEFAULT, Boolean.TRUE);
     }

--- a/src/main/resources/nz/co/breakpoint/jmeter/modifiers/WSSUsernameTokenPreProcessorResources.properties
+++ b/src/main/resources/nz/co/breakpoint/jmeter/modifiers/WSSUsernameTokenPreProcessorResources.properties
@@ -10,3 +10,5 @@ addNonce.displayName=Add Nonce
 addNonce.shortDescription=Whether to add a Nonce element to the UsernameToken
 addCreated.displayName=Add Created
 addCreated.shortDescription=Whether to add a Created element to the UsernameToken
+precisionInMilliSeconds.displayName=Sets precision of timestamp to milliseconds
+precisionInMilliSeconds.shortDescription=Sets precision of timestamp to milliseconds


### PR DESCRIPTION
When target system was implemented by .Net.  Timestamp in created that contains milliseconds will cause password digest wrong. We found that some .Net version will not accept milliseconds precision. So it will be nice if we can set precision in Jmeter.